### PR TITLE
Fix: Update all repository references to wh1teee fork

### DIFF
--- a/perplexity-ask/README.md
+++ b/perplexity-ask/README.md
@@ -34,14 +34,14 @@ Please refer to the official [DeepWiki page](https://deepwiki.com/ppl-ai/modelco
 Clone this repository:
 
 ```bash
-git clone git@github.com:ppl-ai/modelcontextprotocol.git
+git clone git@github.com:wh1teee/mcp-server-perplexity.git
 ```
 
 Navigate to the `perplexity-ask` directory and install the necessary dependencies:
 
 **Using pnpm (recommended):**
 ```bash
-cd modelcontextprotocol/perplexity-ask && pnpm install
+cd mcp-server-perplexity/perplexity-ask && pnpm install
 ```
 
 **Installing pnpm (if not already installed):**
@@ -146,7 +146,7 @@ Currently, the search parameters used are the default ones. You can modify any s
 
 ### Troubleshooting 
 
-The Claude documentation provides an excellent [troubleshooting guide](https://modelcontextprotocol.io/docs/tools/debugging) you can refer to. However, you can still reach out to us at api@perplexity.ai for any additional support or [file a bug](https://github.com/ppl-ai/api-discussion/issues). 
+The Claude documentation provides an excellent [troubleshooting guide](https://modelcontextprotocol.io/docs/tools/debugging) you can refer to. However, you can still reach out to us at api@perplexity.ai for any additional support or [file a bug](https://github.com/wh1teee/mcp-server-perplexity/issues). 
 
 
 # Cursor integration

--- a/perplexity-ask/index.ts
+++ b/perplexity-ask/index.ts
@@ -355,7 +355,7 @@ async function performChatCompletion(
 // Initialize the server with tool metadata and capabilities
 const server = new Server(
   {
-    name: "example-servers/perplexity-ask",
+    name: "mcp-server-perplexity",
     version: "0.1.0",
   },
   {


### PR DESCRIPTION
## Summary
- Update clone commands in README files to use wh1teee/mcp-server-perplexity
- Update directory references from modelcontextprotocol to mcp-server-perplexity  
- Update bug reporting links to point to wh1teee repository
- Update server name in index.ts from example-servers to mcp-server-perplexity
- Keep external documentation links (deepwiki, modelcontextprotocol.io) unchanged

## Test plan
- [x] Verify all repository references point to wh1teee fork
- [x] Ensure external documentation links remain intact
- [x] Test build process works correctly
- [ ] Publish new version to npm after merge